### PR TITLE
cleaning up

### DIFF
--- a/refreshed/big.css
+++ b/refreshed/big.css
@@ -7,12 +7,10 @@
 	right: 0 !important;
 }
 #contentwrapper {
-	margin-left: 12em;
-	margin-right: 12em;
+	margin: 0 12em;
 }
 #footer {
-	margin-left: 14em;
-	margin-right: 14em;
+	margin: 0 14em;
 }
 #leftbar .shower, #rightbar .shower {
 	display: none !important;


### PR DESCRIPTION
Just wondering, why is there some !important declarations? Surely they could still work without them..And if they don't, could we try and use some specificity?
