### PR TITLE
Smaller h1 font size, scroll overflow changes

### DIFF
--- a/Refreshed.skin.php
+++ b/Refreshed.skin.php
@@ -188,10 +188,7 @@ class RefreshedTemplate extends BaseTemplate {
 			<?php } ?>
 			<div id="newtalk"><?php $this->html( 'newtalk' ) ?></div>
 			<div id="maintitle">
-				<h1>
-					<?php $this->html( 'title' ) ?>
-					<div class="mobile-overlay"></div>
-				</h1>
+				<h1 class="scrollshadow"><?php $this->html( 'title' ) ?></h1>
 				<?php
 				$title = $titleBase->getSubjectPage(); // reassigning it because it's changed in #leftbar-top
 				if ( $titleNamespace % 2 == 1 && $titleNamespace > 0 ) { // if talk namespace: talk namespaces are odd positive integers
@@ -241,7 +238,6 @@ class RefreshedTemplate extends BaseTemplate {
 					echo '<a href="javascript:;"><div class="small-icon" id="icon-more"></div></a>';
 				}
 
-				echo '<div class="mobile-overlay"></div>';
 				echo '</div>';
 			} ?>
 			<div id="content">

--- a/refreshed/main.css
+++ b/refreshed/main.css
@@ -43,8 +43,8 @@ body {
 	padding-left: 0.5em;
 	margin-bottom: 0.3em;
 }
-#title-overlay {
-	display: none;
+.scrollshadow {
+	background: none;
 }
 #back-to-subject {
 	display: none;

--- a/refreshed/medium.css
+++ b/refreshed/medium.css
@@ -30,3 +30,23 @@
 #smalltoolboxwrapper {
 	display: none;
 }
+#maintitle h1 {
+	white-space: nowrap;
+	font-size: 2.25em;
+	overflow-x: scroll;
+}
+.scrollshadow {
+	background: 
+		-webkit-linear-gradient(90deg, white 20%, rgba(255,255,255,0)),
+		-webkit-linear-gradient(270deg, white 20%, rgba(255,255,255,0)) 100% 0,
+		-webkit-linear-gradient(90deg, #e3e3e3 10%, rgba(255,255,255,0)),
+		-webkit-linear-gradient(270deg, #e3e3e3 10%, rgba(255,255,255,0)) 100% 0;
+	background: 
+		linear-gradient(90deg, white 20%, rgba(255,255,255,0)),
+		linear-gradient(270deg, white 20%, rgba(255,255,255,0)) 100% 0,
+		linear-gradient(90deg, #e3e3e3 10%, rgba(255,255,255,0)),
+		linear-gradient(270deg, #e3e3e3 10%, rgba(255,255,255,0)) 100% 0;
+	background-repeat: no-repeat;
+	background-size: 40px 100%, 40px 100%, 14px 100%, 14px 100%;
+	background-attachment: local, local, scroll, scroll;
+}

--- a/refreshed/refreshed.js
+++ b/refreshed/refreshed.js
@@ -212,8 +212,7 @@ $( document ).ready( function() {
 	});
 
 	$( '#smalltoolboxwrapper > a' ).click( function() {
-		$( '#smalltoolbox' ).css({'overflow': 'auto'});
-		$( '#smalltoolbox' ).animate({'width': '100%'});
+		$( '#smalltoolbox' ).css({'overflow': 'auto'}).animate({'width': '100%'}).addClass("scrollshadow");
 		$( this ).css({'display': 'none'});
 	});
 } );

--- a/refreshed/small.css
+++ b/refreshed/small.css
@@ -72,26 +72,26 @@
 		border: 0;
 		margin: 0;
 		padding: 0;
+		font-size: 2.25em;
 	}
 	#back-to-subject {
 		display: inline;
 		font-size: .95em;
 	}
-
-.mobile-overlay {
-	display: inline-block;
-	position: absolute;
-	top: 0;
-	right: 0;
-	height: 100%;
-	background: -moz-linear-gradient(left, rgba(255,255,255,0) 0%, rgba(255,255,255,1) 100%); /* FF3.6+ */
-	background: -webkit-gradient(linear, left top, right top, color-stop(0%,rgba(255,255,255,0)), color-stop(100%,rgba(255,255,255,1))); /* Chrome,Safari4+ */
-	background: -webkit-linear-gradient(left, rgba(255,255,255,0) 0%,rgba(255,255,255,1) 100%); /* Chrome10+,Safari5.1+ */
-	background: -o-linear-gradient(left, rgba(255,255,255,0) 0%,rgba(255,255,255,1) 100%); /* Opera 11.10+ */
-	background: -ms-linear-gradient(left, rgba(255,255,255,0) 0%,rgba(255,255,255,1) 100%); /* IE10+ */
-	background: linear-gradient(to right, rgba(255,255,255,0) 0%,rgba(255,255,255,1) 100%); /* W3C */
-	filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#00ffffff', endColorstr='#ffffff',GradientType=1 ); /* IE6-9 */
-	width: 30px;
+.scrollshadow {
+	background: 
+		-webkit-linear-gradient(90deg, white 20%, rgba(255,255,255,0)),
+		-webkit-linear-gradient(270deg, white 20%, rgba(255,255,255,0)) 100% 0,
+		-webkit-linear-gradient(90deg, #e3e3e3 10%, rgba(255,255,255,0)),
+		-webkit-linear-gradient(270deg, #e3e3e3 10%, rgba(255,255,255,0)) 100% 0;
+	background: 
+		linear-gradient(90deg, white 20%, rgba(255,255,255,0)),
+		linear-gradient(270deg, white 20%, rgba(255,255,255,0)) 100% 0,
+		linear-gradient(90deg, #e3e3e3 10%, rgba(255,255,255,0)),
+		linear-gradient(270deg, #e3e3e3 10%, rgba(255,255,255,0)) 100% 0;
+	background-repeat: no-repeat;
+	background-size: 40px 100%, 40px 100%, 14px 100%, 14px 100%;
+	background-attachment: local, local, scroll, scroll;
 }
 
 #smalltoolboxwrapper {


### PR DESCRIPTION
Changes in this commit:
- Smaller h1 font size on mobile and tablet, text overflows on tablet like it does on mobile
- Got rid of whitespace around h1 contents as it messed with side scrolling (sometimes you could scroll past the end of the actual page title)
- Got rid of the current mobile fade, replaced it with the one [here](http://sa.ndropad.in/2013/04/03/horizontal-css-scroll-shadow.html) with the shadow color modified a bit; note it doesn't work fully on Chrome, but that shouldn't be an issue because it's for mobile and tablet
- Got rid of title-overlay in CSS because it's no longer used
