### PR TITLE
Various CSS fixes

### DIFF
--- a/refreshed/big.css
+++ b/refreshed/big.css
@@ -3,20 +3,25 @@
 #leftbar {
 	left: 0 !important;
 }
+
 #rightbar {
 	right: 0 !important;
 }
+
 #contentwrapper {
 	margin-left: 12em;
 	margin-right: 12em;
 }
+
 #footer {
 	margin-left: 14em;
 	margin-right: 14em;
 }
+
 #rightbar .shower {
 	display: none !important;
 }
+
 #smalltoolboxwrapper {
 	display: none;
 }

--- a/refreshed/main.css
+++ b/refreshed/main.css
@@ -4,12 +4,14 @@
 	font-weight: 300;
 	src: local('Lato Light'), local('Lato-Light'), url(http://themes.googleusercontent.com/static/fonts/lato/v6/KT3KS9Aol4WfR6Vas8kNcg.woff) format('woff');
 }
+
 @font-face {
 	font-family: 'Lato';
 	font-style: normal;
 	font-weight: 700;
 	src: local('Lato Bold'), local('Lato-Bold'), url(http://themes.googleusercontent.com/static/fonts/lato/v6/wkfQbvfT_02e2IWO3yYueQ.woff) format('woff');
 }
+
 @font-face {
 	font-family: 'Lato body';
 	font-style: normal;
@@ -25,10 +27,11 @@ body {
 
 #header {
 	background-color: #103ca2;
-	background-image: -moz-linear-gradient(left,#040f28 0,#103ca2 50%,#040f28 100%);
-	background-image: -webkit-gradient(linear,0% 0%,100% 0%,color-stop(0,#040f28),color-stop(50%,#103ca2),color-stop(100%,#040f28));
-	background-image: -o-linear-gradient(left,#040f28 0,#103ca2 50%,#040f28 100%);
-	background-image: -ms-linear-gradient(left,#040f28 0,#103ca2 50%,#040f28 100%);
+	background-image: -moz-linear-gradient(left, #040f28 0, #103ca2 50%, #040f28 100%);
+	background-image: -webkit-gradient(linear, 0% 0%, 100% 0%, color-stop(0, #040f28), color-stop(50%, #103ca2), color-stop(100%, #040f28));
+	background-image: -o-linear-gradient(left, #040f28 0, #103ca2 50%, #040f28 100%);
+	background-image: -ms-linear-gradient(left, #040f28 0, #103ca2 50%, #040f28 100%);
+	background-image: linear-gradient(to left, #040f28 0, #103ca2 50%, #040f28 100%);
 	-webkit-font-smoothing: antialiased;
 	width: 100%;
 	height: 3em;
@@ -43,6 +46,7 @@ body {
 	padding-left: 0.5em;
 	margin-bottom: 0.3em;
 }
+
 .scrollshadow {
 	background: none;
 }
@@ -89,14 +93,15 @@ body {
 }
 
 /*
- * Hide the list bullet icons. This is not terribly useful by default, but there
- * are extensions which can add entire portlets to the sidebar, and said portlets
- * might be using the <ul> HTML tag...
- */
+* Hide the list bullet icons. This is not terribly useful by default, but there
+* are extensions which can add entire portlets to the sidebar, and said portlets
+* might be using the <ul> HTML tag...
+*/
 #rightbar li, #leftbar li {
 	list-style-type: none;
 	margin: 0;
 }
+
 #rightbar ul, #leftbar ul {
 	margin: 0;
 	padding: 0;
@@ -110,11 +115,13 @@ body {
 	height: calc( 100% - 3.5em );
 	left: 0px;
 }
+
 #leftbar-top, #rightbar-top {
 	position: absolute;
 	top: 3em;
 	padding-top: 8px !important;
 }
+
 #leftbar-bottom {
 	position: absolute;
 	bottom: 1em;
@@ -122,70 +129,88 @@ body {
 	width: 100%;
 	right: -1px;
 }
+
 #leftbar-top {
 	right: 0px;
 }
+
 #leftbar-main a, #rightbar-main a {
 	display: block;
 	color: white;
 	text-decoration: none;
 }
+
 #leftbar-main a {
 	padding-left: 10px;
 	text-align: right;
 	margin-right: 5px;
 	direction: ltr; /* ensure direction is correct, as ToC changes it */
 }
+
 #rightbar-main a {
 	text-align: left;
 	margin-left: 5px;
 }
+
 #rightbar .main {
 	padding-left: 10px;
 	display: block;
 	margin-top: 0.5em;
 }
+
 #rightbar .main:first-of-type {
 	margin-top: 0em;
 }
+
 #rightbar .sub {
 	padding-left: 20px;
 }
+
 #leftbar-main a:hover, #rightbar-main a:hover {
 	color: #CCC;
 	cursor: pointer;
 }
+
 #leftbar-main a:hover {
 	border-right: 5px solid #CCC !important;
 	margin-right: 0;
 }
+
 #rightbar-main a:hover {
 	border-left: 5px solid #CCC !important;
 	margin-left: 0;
 }
+
 #leftbar-top li, #rightbar-top li {
 	text-transform: lowercase;
 }
+
 #leftbar-top a {
 	padding-right: 10px;
 }
+
 #leftbar-top > li:first-of-type {
 	text-transform: none;
 }
+
 #leftbar-top > li:nth-of-type(3) > a {
 	margin-top: 0.5em;
 }
+
 #leftbar-top .selected a {
 	border-right: 5px solid white;
 	margin-right: 0;
 }
+
 #leftbar-top .new {
 	color: #fdad9d;
 }
+
 #leftbar-top .new:hover {
 	color: #f47d64;
 	border-color: #f47d64;
 }
+
 #leftbar-top .new.selected a {
 	border-right: 5px solid #fdad9d;
 }
@@ -204,6 +229,7 @@ body {
 	height: 3em;
 	cursor: pointer;
 }
+
 #rightbar .shower {
 	right: 12.5em;
 	width: 48px;
@@ -211,9 +237,11 @@ body {
 	background: url("images/icon-rightbar.png") top left no-repeat;
 	background-size: 48px 48px;
 }
+
 #refreshed-toc {
 	position: relative;
 }
+
 #toc-box {
 	width: 5px;
 	background-color: white;
@@ -221,23 +249,29 @@ body {
 	position: absolute;
 	right: 0;
 }
+
 #leftbar-bottom a {
 	padding-right: 10px;
 	padding-top: 0.15em;
 	padding-bottom: 0.15em;
 }
+
 a.toclevel-2 {
 	padding-right: 20px !important;
 }
+
 a.toclevel-3 {
 	padding-right: 30px !important;
 }
+
 a.toclevel-4 {
 	padding-right: 40px !important;
 }
+
 a.toclevel-5 {
 	padding-right: 50px !important;
 }
+
 a.toclevel-6 {
 	padding-right: 60px !important;
 }
@@ -246,6 +280,7 @@ a.toclevel-6 {
 	position: relative;
 	float: left;
 }
+
 #userinfo > a {
 	display: block;
 	padding: 0.5em;
@@ -257,13 +292,16 @@ a.toclevel-6 {
 	overflow-x: hidden;
 	text-overflow: ellipsis;
 }
+
 #userinfo > a:hover {
 	background-color: midnightblue;
 	color: #CCC;
 }
+
 #userinfo .avatar-none {
 	display: none;
 }
+
 #userinfo > a span {
 	display: block;
 	margin-top: 0.1em;
@@ -272,44 +310,51 @@ a.toclevel-6 {
 	padding-right: 10px;
 	margin-left: 3.5em;
 }
+
 #username-avatar-none {
 	margin-left: 1.75em !important;
 }
+
 #userinfo .arrow {
 	position: absolute;
 	left: 1em;
 	top: 1.2em;
 	vertical-align: text-bottom;
 }
+
 #toolbox-link {
 	margin-top: 0.5em;
 }
+
 #toolbox-link .arrow {
 	vertical-align: 2px;
 }
+
 #userinfo .arrow, #toolbox-link .arrow {
 	-webkit-transition: -webkit-transform 0.5s; /* Safari */
 	-moz-transition: -moz-transform 0.5s; /* Firefox */
 	-ms-transition: -ms-trasform 0.5s; /* IE */
 	transition: transform 0.5s;
+
 	-webkit-transform: rotateZ(0deg); /* Safari */
 	-moz-transform: rotateZ(0deg); /* Firefox */
 	-ms-transform: rotateZ(0deg); /* IE */
 	transform: rotateZ(0deg);
-
 }
+
 #userinfo .arrow.rotate, #toolbox-link .arrow.rotate {
 	-webkit-transform: rotateZ(-180deg); /* Safari */
 	-moz-transform: rotateZ(-180deg); /* Firefox */
 	-ms-transform: rotateZ(-180deg); /* IE */
 	transform: rotateZ(-180deg);
-
 }
+
 #userinfo .avatar {
 	position: absolute;
 	left: 2.5em;
 	width: 30px;
 }
+
 #toolbox-link .no-show {
 	display: none;
 }
@@ -319,14 +364,17 @@ a.toclevel-6 {
 	margin: 0;
 	z-index: 4;
 }
+
 #userinfo .headermenu {
 	background-color: rgb(25, 25, 112);
 	background-color: rgba(25, 25, 112, 0.8);
 }
+
 #siteinfo .headermenu {
 	background-color: rgb(0, 0, 0);
 	background-color: rgba(0, 0, 0, 0.8);
 }
+
 .headermenu a {
 	font-size: 14pt;
 	text-decoration: none;
@@ -334,23 +382,28 @@ a.toclevel-6 {
 	color: white;
 	padding: 0.2em 0.4em 0.2em 0.4em;
 }
+
 .headermenu a:hover {
 	opacity: 1;
 	background-color: midnightblue;
 	text-decoration: none;
 }
+
 .headermenu .new {
 	color: #fdad9d !important;
 }
+
 #userinfo .headermenu {
 	left: 1em;
 	width: 11em;
 	position: absolute;
 }
+
 #userinfo .headermenu a {
 	padding-right: 0.7em !important;
 	text-align: right;
 }
+
 #siteinfo .headermenu {
 	margin: auto;
 	width: 200px;
@@ -363,38 +416,45 @@ a.toclevel-6 {
 	width: 11em;
 	padding: 0.5em 1em 0.5em 1em;
 }
+
 #siteinfo > a:hover {
 	background-color: #222;
 }
+
 #siteinfo > a > img {
 	display: inline-block;
 }
+
 #siteinfo > a > span {
 	font-size: 15pt;
 	color: white;
 }
+
 #siteinfo a {
 	text-align: center;
 }
+
 #siteinfo .arrow {
 	-webkit-transition: -webkit-transform .5s; /* Safari */
 	-moz-transition: -moz-tranform .5s; /* Firefox */
 	-ms-transition: -ms-transform .5s; /* IE */
 	transition: transform .5s;
+
 	-webkit-transform: rotateZ(0deg); /* Safari */
 	-moz-transform: rotateZ(0deg); /* Firefox */
 	-ms-transform: rotateZ(0deg); /* IE */
 	transform: rotateZ(0deg);
+
 	vertical-align: middle;
 	margin-left: 1em;
 	display: inline-block;
 }
+
 #siteinfo .arrow.rotate {
 	-webkit-transform: rotateZ(180deg); /* Safari */
 	-moz-transform: rotateZ(180deg);  /* Firefox */
 	-ms-transform: rotateZ(180deg); /* IE */
 	transform: rotateZ(180deg);
-
 }
 
 #search {
@@ -404,6 +464,7 @@ a.toclevel-6 {
 	right: 0;
 	padding: 0.5em;
 }
+
 #search input {
 	float: right;
 	border: none;
@@ -421,9 +482,11 @@ a.toclevel-6 {
 #preftoc li {
 	display: inline;
 }
+
 #preftoc li:before {
 	content: " - ";
 }
+
 #preftoc li:first-child:before {
 	content: none !important;
 }
@@ -435,18 +498,23 @@ a.toclevel-6 {
 	padding-bottom: 15px;
 	color: #ccc;
 }
+
 #footer a {
 	color: white;
 }
+
 #footer * {
 	line-height: 1.5
 }
+
 #footer img {
 	vertical-align: text-top;
 }
+
 #footer #advert {
 	margin-bottom: 1em; /* enough spacing after ad */
 }
+
 #footer #advert p {
 	margin: 0;
 }
@@ -474,9 +542,11 @@ h6 {
 	position: static !important;
 	float: right;
 }
+
 .mw-search-formheader {
 	border: none !important;
 }
+
 #search input#searchText {
 	border: 1px solid #CCC !important
 }
@@ -505,35 +575,41 @@ h6 {
 	background: url(../../monobook/external-ltr.png) center right no-repeat;
 	padding-right: 13px;
 }
+
 #content a.external[href ^="https://"],
 .link-https {
 	/* @embed */
 	background: url(../../monobook/lock_icon.gif) center right no-repeat;
 	padding-right: 16px;
 }
+
 #content a.external[href ^="mailto:"],
 .link-mailto {
 	/* @embed */
 	background: url(../../monobook/mail_icon.gif) center right no-repeat;
 	padding-right: 18px;
 }
+
 #content a.external[href ^="news://"] {
 	/* @embed */
 	background: url(../../monobook/news_icon.png) center right no-repeat;
 	padding-right: 18px;
 }
+
 #content a.external[href ^="ftp://"],
 .link-ftp {
 	/* @embed */
 	background: url(../../monobook/file_icon.gif) center right no-repeat;
 	padding-right: 18px;
 }
+
 #content a.external[href ^="irc://"],
 .link-irc {
 	/* @embed */
 	background: url(../../monobook/discussionitem_icon.gif) center right no-repeat;
 	padding-right: 18px;
 }
+
 #content a.external[href $=".ogg"], #content a.external[href $=".OGG"],
 #content a.external[href $=".mid"], #content a.external[href $=".MID"],
 #content a.external[href $=".midi"], #content a.external[href $=".MIDI"],
@@ -545,6 +621,7 @@ h6 {
 	background: url("../../monobook/audio.png") center right no-repeat;
 	padding-right: 13px;
 }
+
 #content a.external[href $=".ogm"], #content a.external[href $=".OGM"],
 #content a.external[href $=".avi"], #content a.external[href $=".AVI"],
 #content a.external[href $=".mpeg"], #content a.external[href $=".MPEG"],
@@ -554,6 +631,7 @@ h6 {
 	background: url("../../monobook/video.png") center right no-repeat;
 	padding-right: 13px;
 }
+
 #content a.external[href $=".pdf"], #content a.external[href $=".PDF"],
 #content a.external[href *=".pdf#"], #content a.external[href *=".PDF#"],
 #content a.external[href *=".pdf?"], #content a.external[href *=".PDF?"],
@@ -582,9 +660,11 @@ h6 {
 	-webkit-text-shadow: none !important;
 	-moz-text-shadow: none !important;
 	text-shadow: none !important;
+
 	-webkit-border-radius: 0px !important;
 	-moz-border-radius: 0px !important;
 	border-radius: 0px !important;
+
 	-webkit-box-shadow: none !important;
 	-moz-box-shadow: none !important;
 	box-shadow: none !important;

--- a/refreshed/medium.css
+++ b/refreshed/medium.css
@@ -3,23 +3,28 @@
 #leftbar {
 	left: 0 !important;
 }
+
 #rightbar {
 	width: 12em;
 	right: -12em;
 	background: rgb(25, 25, 112);
 	background-color: rgba(25, 25, 112, 0.8);
 }
+
 #rightbar .shower {
 	width: 48px;
 }
+
 #contentwrapper {
 	margin-left: 12em;
 	margin-right: 1em;
 }
+
 #footer {
 	margin-left: 14em;
 	margin-right: 2em;
 }
+
 #siteinfo .headermenu,
 #siteinfo > a {
 	margin-left: -webkit-calc(50% - 1em);
@@ -30,18 +35,20 @@
 #smalltoolboxwrapper {
 	display: none;
 }
+
 #maintitle h1 {
 	white-space: nowrap;
 	font-size: 2.25em;
 	overflow-x: scroll;
 }
+
 .scrollshadow {
-	background: 
+	background:
 		-webkit-linear-gradient(90deg, white 20%, rgba(255,255,255,0)),
 		-webkit-linear-gradient(270deg, white 20%, rgba(255,255,255,0)) 100% 0,
 		-webkit-linear-gradient(90deg, #e3e3e3 10%, rgba(255,255,255,0)),
 		-webkit-linear-gradient(270deg, #e3e3e3 10%, rgba(255,255,255,0)) 100% 0;
-	background: 
+	background:
 		linear-gradient(90deg, white 20%, rgba(255,255,255,0)),
 		linear-gradient(270deg, white 20%, rgba(255,255,255,0)) 100% 0,
 		linear-gradient(90deg, #e3e3e3 10%, rgba(255,255,255,0)),

--- a/refreshed/refreshed.js
+++ b/refreshed/refreshed.js
@@ -35,7 +35,7 @@ var Refreshed = {
 				heightDiff = heightBelow - heightAbove,
 				heightMeRelative = height - heightAbove,
 				fractMe = heightMeRelative / heightDiff;
-	
+
 			var elemAbove = $( 'a[data-numid=' + idAbove + ']' ),
 				elemAboveOffset = elemAbove.position().top,
 				elemBelow = $( 'a[data-numid=' + idBelow + ']' ),
@@ -70,7 +70,7 @@ var Refreshed = {
 			} );
 
 			$( window ).scroll( Refreshed.onScroll );
-			
+
 		} else if ( overlap < 16 ) {
 			$( '#leftbar-bottom' ).css( {
 				'overflow-y': 'hidden',
@@ -153,7 +153,7 @@ $( document ).ready( function() {
 	});
 
 	$( window ).scroll( function() {
-		if ( $( '#refreshed-toc a' ).length != 0 ) {
+		if ( $( '#refreshed-toc a' ).length !== 0 ) {
 			Refreshed.moveBoxTo( $( this ).scrollTop() );
 		}
 	});

--- a/refreshed/small.css
+++ b/refreshed/small.css
@@ -5,58 +5,73 @@
 	width: 46px;
 	height: 48px;
 }
+
 #leftbar-main {
 	display: none;
 }
+
 #rightbar {
 	right: -12em;
 	background-color: rgb(25, 25, 112);
 }
+
 #rightbar .shower {
 	right: 12em;
 }
+
 #rightbar #rightbar-main {
 	font-size: 14pt;
 	font-weight: normal;
 }
+
 #userinfo .arrow {
 	display: none;
 }
+
 #userinfo .avatar {
 	left: .5em;
 }
+
 #userinfo .avatar-none {
 	display: block;
 }
+
 #userinfo > a {
 	width: 30px;
 	min-width: 30px;
 }
+
 #userinfo .avatar-none {
 	display: block;
 }
+
 #userinfo > a span {
 	display: none;
 }
+
 #userinfo .headermenu {
 	left: 0;
 	background-color: rgb(25, 25, 112);
 	padding: 0.15em 0 0.15em 0;
 }
+
 #userinfo .headermenu a {
 	text-align: left;
 	padding-left: 15px;
 	font-weight: normal;
 }
+
 #userinfo .headermenu a:hover {
 	border-left: 5px solid #CCC;
 	color: #CCC;
 	padding-left: 10px;
 }
+
 #userinfo .headermenu a.new:hover {
 	color: #f47d64 !important;
 	border-color: #f47d64;
 }
+
 #maintitle {
 	position: relative;
 	margin-bottom: 5px;
@@ -66,18 +81,21 @@
 	font-size: 0.9em;
 	padding-bottom: 5px;
 }
-	#maintitle h1 {
-		overflow-x: auto;
-		white-space: nowrap;
-		border: 0;
-		margin: 0;
-		padding: 0;
-		font-size: 2.25em;
-	}
-	#back-to-subject {
-		display: inline;
-		font-size: .95em;
-	}
+
+#maintitle h1 {
+	overflow-x: auto;
+	white-space: nowrap;
+	border: 0;
+	margin: 0;
+	padding: 0;
+	font-size: 2.25em;
+}
+
+#back-to-subject {
+	display: inline;
+	font-size: .95em;
+}
+
 .scrollshadow {
 	background:
 		-webkit-linear-gradient(90deg, white 20%, rgba(255,255,255,0)),
@@ -97,22 +115,22 @@
 #smalltoolboxwrapper {
 	position: relative;
 	display: block;
-    border-bottom: 1px solid #eaeaea;
-    margin-left: 15px;
+	border-bottom: 1px solid #eaeaea;
+	margin-left: 15px;
 }
 
 #smalltoolbox {
 	position: relative;
-    width: 96px;
-    white-space: nowrap;
-    overflow: hidden;
-    display: inline-block;
+	width: 96px;
+	white-space: nowrap;
+	overflow: hidden;
+	display: inline-block;
 }
 
 .small-icon {
-    width: 48px;
-    height: 48px;
-    background-size: 48px 48px;
+	width: 48px;
+	height: 48px;
+	background-size: 48px 48px;
 	display: inline-block;
 }
 #icon-ca-talk {
@@ -123,7 +141,7 @@
 #icon-ca-viewsource {
 	/* @embed */
 	background-image: url("images/icon-edit.png");
-    opacity: .3;
+	opacity: .3;
 }
 
 #icon-ca-edit {
@@ -174,7 +192,7 @@
 #icon-ca-addsection,
 #icon-ca-purge,
 #icon-ca-talk.selected {
-    display: none;
+	display: none;
 }
 
 /* CONTENT AREA ********************************************/


### PR DESCRIPTION
- Trimed excess whitespace
- Converted to tabs (if file needed, see note)
- Single line between rules to ease reading
- Fixed vendor prefix issues from Brickimedia/brickimedia#187
- Fixed JavaScript comparison issue (_always_ use [`===` and `!==`](http://www.impressivewebs.com/why-use-triple-equals-javascipt/))

Both `big.css` and `small.css` validate in the W3C CSS validator. `main.css` and `medium.css` each have three errors (you are taking a `%` and subtracting `em`).

**Note:** I converted the files to tabs because most of them were already that way. If I need to convert them to spaces, just say the word. :)
