### PR TITLE
removing some unnecessary vendor prefixes

### DIFF
--- a/refreshed/main.css
+++ b/refreshed/main.css
@@ -40,27 +40,19 @@
 	font-size: 1em; /* make the definition of the arrow's em the same as its parent's so it's easier to position using em units... */
 	line-height: 3em;
 	height: 3em; /* line-height and height equal to the parent's height (3em) plus vertical-align:text-bottom in wikiglyphs.css vertically centers the icons */
-
 	-ms-transform: translateY(-3%); /* we don't want the arrows to have translateY (which is applied to .wikiglyph elements). Instead we change the transform-origin (see below) */
-	-o-transform: translateY(-3%);
-	-moz-transform: translateY(-3%);
-	-webkit-transform: translateY(-3%); /* -webkit- last so it's used in place of -o- if possible */
 	transform: translateY(-3%);
 }
 
 .fadable {
-	-o-transition: opacity 0.2s ease;
-	-moz-transition: opacity 0.2s ease;
-	-webkit-transition: opacity 0.2s ease; /* -webkit- last so it's used in place of -o- if possible */
+	-ms-transition: opacity 0.2s ease;
 	transition: opacity 0.2s ease;
 	opacity: 1;
 	visibility: visible;
 }
 
 .faded {
-	-o-transition: opacity 0.2s ease, visibility 0.2s;
-	-moz-transition: opacity 0.2s ease, visibility 0.2s;
-	-webkit-transition: opacity 0.2s ease, visibility 0.2s; /* -webkit- last so it's used in place of -o- if possible */
+	-ms-transition: opacity 0.2s ease, visibility 0.2s;
 	transition: opacity 0.2s ease, visibility 0.2s;
 	opacity: 0;
 	visibility: hidden;
@@ -85,15 +77,8 @@
 
 .header-button .arrow {
 	-ms-transform: translateY(0); /* we don't want the arrows to have translateY (which is applied to .wikiglyph elements). Instead we change the transform-origin (see below) */
-	-o-transform: translateY(0);
-	-moz-transform: translateY(0);
-	-webkit-transform: translateY(0); /* -webkit- last so it's used in place of -o- if possible */
 	transform: translateY(0);
-
 	-ms-transform-origin: 50% 52%; /* the icon itself (i.e. the arrow inside the SVG) is subtly off vertical center, making it look slightly off when animated; this line counterbalances that for the animation */
-	-o-transform-origin: 50% 52%;
-	-moz-transform-origin: 50% 52%;
-	-webkit-transform-origin: 50% 52%; /* -webkit- last so it's used in place of -o- if possible */
 	transform-origin: 50% 52%;
 }
 
@@ -113,9 +98,7 @@ body {
 	left: 0;
 	display: block;
 	opacity: 0;
-	-o-transition: opacity 0.2s ease;
-	-moz-transition: opacity 0.2s ease;
-	-webkit-transition: opacity 0.2s ease; /* -webkit- last so it's used in place of -o- if possible */
+	-ms-transition: opacity 0.2s ease;
 	transition: opacity 0.2s ease;
 	background: #fff;
 }
@@ -151,14 +134,11 @@ a.header-button { /* double selectors to override default a element text-decorat
 #header-inner {
 	height: 100%;
 	background-color: #103ca2;
-	background-image: -webkit-gradient(linear, 0% 0%, 100% 0%, color-stop(0, #040f28), color-stop(50%, #103ca2), color-stop(100%, #040f28));
 	/* IE5.5-IE7 */
 	filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#040f28', endColorstr='#103ca2', GradientType=1);
 	/* IE8 */
 	-ms-filter: "progid:DXImageTransform.Microsoft.Gradient(GradientType=1,StartColorStr=#040f28,EndColorStr=#103ca2)";
 	/* IE9+ */
-	background-image: -webkit-gradient(linear, right top, left top, color-stop(0, #040f28), color-stop(50%, #103ca2), to(#040f28));
-	background-image: -webkit-linear-gradient(right, #040f28 0, #103ca2 50%, #040f28 100%);
 	background-image: linear-gradient(to left, #040f28 0, #103ca2 50%, #040f28 100%);
 }
 
@@ -199,7 +179,7 @@ a.header-button { /* double selectors to override default a element text-decorat
 }
 
 #header-categories li img {
-	margin: 00.5em 3px 4px;
+	margin: 0.5em 3px 4px;
 }
 
 #header-categories .header-category-menu {
@@ -358,9 +338,6 @@ a.header-button { /* double selectors to override default a element text-decorat
 
 .dropdown-open {
 	-ms-transform: translateY(3em);
-	-o-transform: translateY(3em);
-	-moz-transform: translateY(3em);
-	-webkit-transform: translateY(3em); /* -webkit- last so it's used in place of -o- if possible */
 	transform: translateY(3em);
 }
 
@@ -523,17 +500,11 @@ a.header-button { /* double selectors to override default a element text-decorat
 }
 
 .arrow {
-	-o-transition: -o-transform 0.5s;
-	-moz-transition: -moz-transform 0.5s;
-	-webkit-transition: -webkit-transform 0.5s; /* -webkit- last so it's used in place of -o- if possible */
+	-ms-transition: transform 0.5s;
 	transition: transform 0.5s;
 }
 
 .arrow.rotate {
-	-ms-transform: rotate(-180deg);
-	-o-transform: rotate(-180deg);
-	-moz-transform: rotate(-180deg);
-	-webkit-transform: rotate(-180deg); /* -webkit- last so it's used in place of -o- if possible */
 	transform: rotate(-180deg);
 }
 
@@ -584,9 +555,7 @@ a.header-button { /* double selectors to override default a element text-decorat
 	background-image: url(images/icon-rightbar.png);
 	background-size: 3em;
 	display: none;
-	-o-transition: right 0.2s ease 0s;
-	-moz-transition: right 0.2s ease 0s;
-	-webkit-transition: right 0.2s ease 0s; /* -webkit- last so it's used in place of -o- if possible */
+	-ms-transition: right 0.2s ease 0s;
 	transition: right 0.2s ease 0s;
 }
 
@@ -781,15 +750,6 @@ h6 {
 	border: 0;
 	/* same as .scrollshadow, but #f9f9f9 instead of white */
 	background:
-		-webkit-linear-gradient(90deg, #f9f9f9 20%, rgba(255,255,255,0)),
-		-webkit-linear-gradient(270deg, #f9f9f9 20%, rgba(255,255,255,0)) 100% 0,
-		-webkit-linear-gradient(90deg, #e3e3e3 10%, rgba(255,255,255,0)),
-		-webkit-linear-gradient(270deg, #e3e3e3 10%, rgba(255,255,255,0)) 100% 0;
-	background:
-		linear-gradient(90deg, #f9f9f9 20%, rgba(255,255,255,0)), linear-gradient(270deg, #f9f9f9 20%, rgba(255,255,255,0)) 100% 0, linear-gradient(90deg, #e3e3e3 10%, rgba(255,255,255,0)), linear-gradient(270deg, #e3e3e3 10%, rgba(255,255,255,0)) 100% 0;
-	background:
-		-webkit-linear-gradient(0deg, #f9f9f9 20%, rgba(255,255,255,0)), -webkit-linear-gradient(180deg, #f9f9f9 20%, rgba(255,255,255,0)) 100% 0, -webkit-linear-gradient(0deg, #e3e3e3 10%, rgba(255,255,255,0)), -webkit-linear-gradient(180deg, #e3e3e3 10%, rgba(255,255,255,0)) 100% 0;
-	background:
 		linear-gradient(90deg, #f9f9f9 20%, rgba(255,255,255,0)),
 		linear-gradient(270deg, #f9f9f9 20%, rgba(255,255,255,0)) 100% 0,
 		linear-gradient(90deg, #e3e3e3 10%, rgba(255,255,255,0)),
@@ -826,10 +786,8 @@ h6 {
 	line-height: 1em !important;
 	top: 3px !important;
 	border: none !important;
-	-webkit-text-shadow: none !important;
-	-moz-text-shadow: none !important;
 	text-shadow: none !important;
-	border-radius: 0px !important;
+	border-radius: 0 !important;
 	box-shadow: none !important;
 }
 


### PR DESCRIPTION
- removing vendor prefixes for:
 - CSS transitions (support on most major browsers / src: http://caniuse.com/#feat=css-transitions )
 - 2D transforms except for IE8 until further notice (support on most major browsers / src: http://caniuse.com/#feat=transforms2d )
 - CSS gradients except for IE8+ until further notice (support on most major browsers / src: http://caniuse.com/#search=CSS%20gradient )
 - text-shadow (support on most major browsers / src: http://caniuse.com/#search=text-shadow )