### PR TITLE
removing font support for IE8 and older

### DIFF
--- a/refreshed/iefontfix.css
+++ b/refreshed/iefontfix.css
@@ -5,7 +5,6 @@
 	src: url(https://fonts.gstatic.com/s/lato/v11/zLhfkPOm_5ykmdm-wXaiuw.eot);
   src: local('Lato Light'),
 		local('Lato-Light'),
-		url(https://fonts.gstatic.com/s/lato/v11/zLhfkPOm_5ykmdm-wXaiuw.eot?#iefix) format('embedded-opentype'),
 		url(https://fonts.gstatic.com/s/lato/v11/kcf5uOXucLcbFOydGU24WALUuEpTyoUstqEm5AMlJo4.woff) format('woff'),
 		url(https://fonts.gstatic.com/s/lato/v11/nj47mAZe0mYUIySgfn0wpQ.ttf) format('truetype'),
 		url(https://fonts.gstatic.com/l/font?kit=7yKIrlBXX_AXuUv3Ts9_8g#Lato) format('svg');
@@ -17,8 +16,7 @@
 	font-weight: 700;
 	src: url(https://fonts.gstatic.com/s/lato/v11/sBtfDPlEIwvKKU53nAG7AQ.eot);
 	src: local('Lato Bold'),
-		local('Lato-Bold'),
-		url(https://fonts.gstatic.com/s/lato/v11/sBtfDPlEIwvKKU53nAG7AQ.eot?#iefix) format('embedded-opentype'),
+		local('Lato-Bold'),,
 		url(https://fonts.gstatic.com/s/lato/v11/qdgUG4U09HnJwhYI-uK18wLUuEpTyoUstqEm5AMlJo4.woff) format('woff'),
 		url(https://fonts.gstatic.com/s/lato/v11/DvlFBScY1r-FMtZSYIYoYw.ttf) format('truetype'),
 		url(https://fonts.gstatic.com/l/font?kit=hLECvlEj3pKlnS4NFs8NQw#Lato) format('svg');
@@ -31,7 +29,6 @@
 	src: url(https://fonts.gstatic.com/s/lato/v11/nQhiC-wSiJx0pvEuJl8d8A.eot);
 	src: local('Lato Regular'),
 		local('Lato-Regular'),
-		url(https://fonts.gstatic.com/s/lato/v11/nQhiC-wSiJx0pvEuJl8d8A.eot?#iefix) format('embedded-opentype'),
 		url(https://fonts.gstatic.com/s/lato/v11/qIIYRU-oROkIk8vfvxw6QvesZW2xOQ-xsNqO47m55DA.woff) format('woff'),
 		url(https://fonts.gstatic.com/s/lato/v11/v0SdcGFAl2aezM9Vq_aFTQ.ttf) format('truetype'),
 		url(https://fonts.gstatic.com/l/font?kit=H4oiIt_Ug9TU5ast0nUT-w#Lato) format('svg');
@@ -40,8 +37,7 @@
 @font-face {
     font-family: 'WikiFont-Glyphs';
     src: url('wikifont/WikiFont-Glyphs.eot'); /* IE9 Compat Modes */
-    src: url('wikifont/WikiFont-Glyphs.eot?#iefix') format('embedded-opentype'), /* IE6-IE8 */
-         url('wikifont/WikiFont-Glyphs.woff') format('woff'), /* Modern Browsers */
+    src: url('wikifont/WikiFont-Glyphs.woff') format('woff'), /* Modern Browsers */
          url('wikifont/WikiFont-Glyphs.ttf')  format('truetype'), /* Safari, Android, iOS */
          url('wikifont/WikiFont-Glyphs.svg#8088f7bbbdba5c9832b27edb3dfcdf09') format('svg'); /* Legacy iOS */
 }


### PR DESCRIPTION
Should also be beneficial since it's loading 4 less files than before